### PR TITLE
Add "user:invite" command

### DIFF
--- a/Commands/InviteUser.php
+++ b/Commands/InviteUser.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://digitalist.se/contributing-matomo
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UserConsole\Commands;
+
+use Piwik\Plugin\ConsoleCommand;
+use Piwik\Plugins\UsersManager\API as APIUsersManager;
+
+/**
+ * Invite a user.
+ */
+class InviteUser extends ConsoleCommand
+{
+    /**
+     * Options for user creation.
+     */
+    protected function configure()
+    {
+        $this->setName('user:invite');
+        $this->setDescription('Invite user');
+        $this->addRequiredValueOption(
+            'login',
+            null,
+            'User login name',
+            null
+        );
+        $this->addRequiredValueOption(
+            'email',
+            null,
+            'User email',
+            null
+        );
+        $this->addRequiredValueOption(
+            'site',
+            null,
+            'ID of the initial site',
+            null
+        );
+        $this->addOptionalValueOption(
+            'expiry',
+            null,
+            'Expiry in days',
+            null
+        );
+    }
+
+    /**
+     * Create an user, with option to create super user.
+     */
+    protected function doExecute(): int
+    {
+        $input = $this->getInput();
+        $output = $this->getOutput();
+        $login = $input->getOption('login');
+        $email = $input->getOption('email');
+        $site = $input->getOption('site');
+        $expiry = $input->getOption('expiry');
+        $api = APIUsersManager::getInstance();
+
+        if ($api->userExists($login) || $api->userEmailExists($email)) {
+            $output->writeln("<error>User with login name $login or/and email $email already exists.</error>");
+
+            return self::SUCCESS;
+        }
+
+        $api->inviteUser($login, $email, $site, $expiry);
+
+        $output->writeln("<info>User $login invited</info>");
+
+        return self::SUCCESS;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ This plugin adds the possibility to work with users via console commands.
 
 ## Console commands
 
-* [user:access](#useraccess) 
+* [user:access](#useraccess)
 * [user:create](#usercreate)
-* [user:delete](#userdelete) 
+* [user:invite](#userinvite)
+* [user:delete](#userdelete)
 * [user:list](#userlist)
 * [user:make-super](#makesuper)
 * [user:remove-super](#removesuper)
@@ -25,11 +26,22 @@ Options:
 * `password` Password for the user (required)
 * `super` Add super user privileges to the user (optional)
 
+### <a name="userinvite">user:invite</a>
+
+Invites a user.
+
+Options:
+
+* `login` User name for the user (required)
+* `email` Email for the user (required)
+* `site` ID of the initial site (required)
+* `expiry` Expiry in days (optional)
+
 ### <a name="userdelete">user:delete</a>
 
-Deletes a user. 
+Deletes a user.
 
-Options: 
+Options:
 
 * `login` User name for the user (required)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,10 @@ This plugin adds the possibility to work with users via console commands.
 
 ## Console commands
 
-* [user:access](#useraccess) 
+* [user:access](#useraccess)
 * [user:create](#usercreate)
-* [user:delete](#userdelete) 
+* [user:invite](#userinvite)
+* [user:delete](#userdelete)
 * [user:list](#userlist)
 * [user:make-super](#makesuper)
 * [user:remove-super](#removesuper)
@@ -25,11 +26,22 @@ Options:
 * `password` Password for the user (required)
 * `super` Add super user privileges to the user (optional)
 
+### <a name="userinvite">user:invite</a>
+
+Invites a user.
+
+Options:
+
+* `login` User name for the user (required)
+* `email` Email for the user (required)
+* `site` ID of the initial site (required)
+* `expiry` Expiry in days (optional)
+
 ### <a name="userdelete">user:delete</a>
 
-Deletes a user. 
+Deletes a user.
 
-Options: 
+Options:
 
 * `login` User name for the user (required)
 


### PR DESCRIPTION
Fixes #5

Notice that due to a lack of an actual user on console the invitation mail will say something like this:

> **super user was set** sent you an invite to join Matomo Analytics for **Example**.

See https://github.com/matomo-org/matomo/blob/5.1.2/core/Access.php#L234